### PR TITLE
fix(progressbar): バーが見えない問題を修正

### DIFF
--- a/src/components/atoms/ProgressBar/ProgressBar.stories.tsx
+++ b/src/components/atoms/ProgressBar/ProgressBar.stories.tsx
@@ -59,3 +59,13 @@ export const CustomMax: Story = {
     label: "Progress 32/40",
   },
 };
+
+export const VisibilityStates: Story = {
+  render: () => (
+    <div className="space-y-4">
+      <ProgressBar value={0} max={100} label="Progress 0/100" />
+      <ProgressBar value={30} max={100} label="Progress 30/100" />
+      <ProgressBar value={100} max={100} label="Progress 100/100" />
+    </div>
+  ),
+};

--- a/src/components/atoms/ProgressBar/ProgressBar.test.tsx
+++ b/src/components/atoms/ProgressBar/ProgressBar.test.tsx
@@ -75,4 +75,30 @@ describe("ProgressBar", () => {
       "100",
     );
   });
+
+  it("トラックとフィルにテーマCSS変数の背景色が適用される", () => {
+    const { container } = render(<ProgressBar value={30} />);
+    const progressbar = screen.getByRole("progressbar");
+    const fill = container.querySelector('div[style="width: 30%;"]');
+
+    expect(progressbar).toHaveClass("bg-[var(--kui-color-info-subtle)]");
+    expect(fill).toHaveClass("bg-[var(--kui-color-info)]");
+  });
+
+  it("0 / 30 / 100 の値で幅が正しく計算される", () => {
+    const { container, rerender } = render(<ProgressBar value={0} />);
+    expect(
+      container.querySelector('div[style="width: 0%;"]'),
+    ).toBeInTheDocument();
+
+    rerender(<ProgressBar value={30} />);
+    expect(
+      container.querySelector('div[style="width: 30%;"]'),
+    ).toBeInTheDocument();
+
+    rerender(<ProgressBar value={100} />);
+    expect(
+      container.querySelector('div[style="width: 100%;"]'),
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/atoms/ProgressBar/ProgressBar.tsx
+++ b/src/components/atoms/ProgressBar/ProgressBar.tsx
@@ -50,14 +50,14 @@ export const ProgressBar: React.FC<ProgressBarProps> = ({
       aria-valuemax={safeMax}
       aria-label={label}
       className={cn(
-        "w-full overflow-hidden rounded-full bg-[--kui-color-surface-raised]",
+        "w-full overflow-hidden rounded-full bg-[var(--kui-color-info-subtle)]",
         sizeStyles[size],
         className,
       )}
       {...props}
     >
       <div
-        className="h-full rounded-full bg-[--kui-color-info] transition-all duration-500 ease-in-out"
+        className="h-full rounded-full bg-[var(--kui-color-info)] transition-all duration-500 ease-in-out"
         style={{ width: `${progressPercentage}%` }}
       />
     </div>


### PR DESCRIPTION
## Summary
- ProgressBar の背景色指定を Tailwind 任意値の正しい構文 (var(--...)) に修正
- トラック色を info-subtle、フィル色を info に統一しライト/ダークで視認可能に調整
- Storybook に 0/30/100 の表示確認ストーリーを追加
- テストに CSS変数適用と 0/30/100 幅計算の検証を追加

## Test
- pnpm test src/components/atoms/ProgressBar/ProgressBar.test.tsx
- pnpm biome check src/components/atoms/ProgressBar/ProgressBar.tsx src/components/atoms/ProgressBar/ProgressBar.stories.tsx src/components/atoms/ProgressBar/ProgressBar.test.tsx
- pnpm typecheck

Closes #37