### PR TITLE
feat(textarea): onKeyDown等の標準属性を透過

### DIFF
--- a/src/components/atoms/Textarea/Textarea.test.tsx
+++ b/src/components/atoms/Textarea/Textarea.test.tsx
@@ -117,4 +117,55 @@ describe("Textarea", () => {
     const { container } = render(<Textarea className="mt-4" />);
     expect(container.firstChild).toHaveClass("mt-4");
   });
+
+  it("onKeyDown が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const handleKeyDown = vi.fn();
+    render(<Textarea onKeyDown={handleKeyDown} />);
+
+    await user.type(screen.getByRole("textbox"), "{enter}");
+    expect(handleKeyDown).toHaveBeenCalled();
+  });
+
+  it("onFocus / onBlur が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const handleFocus = vi.fn();
+    const handleBlur = vi.fn();
+    render(<Textarea onFocus={handleFocus} onBlur={handleBlur} />);
+
+    const textarea = screen.getByRole("textbox");
+    await user.click(textarea);
+    await user.tab();
+
+    expect(handleFocus).toHaveBeenCalled();
+    expect(handleBlur).toHaveBeenCalled();
+  });
+
+  it("name / id / aria-* が透過される", () => {
+    render(
+      <Textarea
+        id="custom-textarea-id"
+        name="message"
+        aria-label="Message"
+        aria-describedby="hint-id"
+      />,
+    );
+
+    const textarea = screen.getByRole("textbox");
+    expect(textarea).toHaveAttribute("id", "custom-textarea-id");
+    expect(textarea).toHaveAttribute("name", "message");
+    expect(textarea).toHaveAttribute("aria-label", "Message");
+    expect(textarea).toHaveAttribute("aria-describedby", "hint-id");
+  });
+
+  it("error があるとき aria-describedby に既存値と error id の両方が入る", () => {
+    render(<Textarea error="Error" aria-describedby="hint-id" />);
+    const textarea = screen.getByRole("textbox");
+    const errorElement = screen.getByRole("alert");
+
+    expect(textarea).toHaveAttribute(
+      "aria-describedby",
+      `hint-id ${errorElement.id}`,
+    );
+  });
 });

--- a/src/components/atoms/Textarea/Textarea.tsx
+++ b/src/components/atoms/Textarea/Textarea.tsx
@@ -8,13 +8,10 @@ import { cn } from "../../../utils/cn";
 /** テキストエリアのサイズ */
 export type TextareaSize = "small" | "medium" | "large";
 
-export interface TextareaProps {
+export interface TextareaProps
+  extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, "onChange"> {
   /** ラベルテキスト */
   label?: string;
-  /** 必須フラグ（ラベルに * を付与する） */
-  required?: boolean;
-  /** プレースホルダー */
-  placeholder?: string;
   /** エラーメッセージ（指定されるとエラー状態を表示する） */
   error?: string;
   /** 現在の値 */
@@ -60,18 +57,23 @@ const errorSizeStyles: Record<TextareaSize, string> = {
 export const Textarea: React.FC<TextareaProps> = ({
   label,
   required = false,
-  placeholder,
   error,
   value,
   onChange,
-  disabled = false,
   size = "medium",
   rows = 3,
   className,
+  id,
+  "aria-describedby": ariaDescribedBy,
+  ...textareaProps
 }) => {
   const baseId = useId();
-  const textareaId = `${baseId}-textarea`;
+  const textareaId = id ?? `${baseId}-textarea`;
   const errorId = `${baseId}-error`;
+  const mergedAriaDescribedBy = [ariaDescribedBy, error ? errorId : undefined]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
 
   return (
     <div className={cn("flex flex-col", className)}>
@@ -100,12 +102,11 @@ export const Textarea: React.FC<TextareaProps> = ({
         id={textareaId}
         value={value}
         onChange={(e) => onChange?.(e.target.value)}
-        disabled={disabled}
-        placeholder={placeholder}
         required={required}
         rows={rows}
+        {...textareaProps}
         aria-invalid={!!error}
-        aria-describedby={error ? errorId : undefined}
+        aria-describedby={mergedAriaDescribedBy || undefined}
         className={cn(
           "w-full rounded-md border bg-white transition-colors duration-150",
           "text-gray-900 placeholder:text-gray-400",
@@ -122,7 +123,7 @@ export const Textarea: React.FC<TextareaProps> = ({
                 "focus:outline-none focus:ring-2 focus:ring-[var(--kui-color-info)] focus:ring-offset-1",
                 "dark:border-gray-600",
               ],
-          disabled && "cursor-not-allowed opacity-50",
+          textareaProps.disabled && "cursor-not-allowed opacity-50",
         )}
       />
       {/* エラーメッセージ */}


### PR DESCRIPTION
## Summary
- TextareaProps を React.TextareaHTMLAttributes ベースに拡張し、onKeyDown / onBlur / onFocus / name / id / aria-* など標準属性を透過
- id 指定時はその値を優先し、ラベル htmlFor と正しく連携
- aria-describedby は既存値とエラーメッセージIDをマージして共存
- Storybook に Enter送信・Shift+Enter改行・IME変換中Enter無視のキーボードイベント利用例を追加
- テストを追加してイベント透過と標準属性透過を検証

## Test
- pnpm vitest run src/components/atoms/Textarea/Textarea.test.tsx
- pnpm biome check src/components/atoms/Textarea/Textarea.tsx src/components/atoms/Textarea/Textarea.test.tsx src/components/atoms/Textarea/Textarea.stories.tsx

Closes #26