### PR TITLE
feat(select): clearableと標準属性透過を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,24 @@ import { Card, Typography } from "k-ui";
 </Card>;
 ```
 
+```tsx
+import { Select } from "k-ui";
+
+<Select
+  label="Fruit"
+  name="fruit"
+  placeholder="Select a fruit"
+  clearable
+  options={[
+    { label: "Apple", value: "apple" },
+    { label: "Banana", value: "banana" },
+  ]}
+  onChange={(value) => console.log(value)}
+/>;
+```
+
+`Select` は `name / id / onBlur / onFocus / aria-*` など標準の `select` 属性を透過できる。
+
 Tailwind CSS プリセットも提供している。
 
 ```ts

--- a/src/components/atoms/Select/Select.stories.tsx
+++ b/src/components/atoms/Select/Select.stories.tsx
@@ -25,6 +25,9 @@ const meta = {
     required: {
       control: "boolean",
     },
+    clearable: {
+      control: "boolean",
+    },
   },
   args: {
     options: sampleOptions,
@@ -132,6 +135,18 @@ export const WithDisabledOption: Story = {
       { label: "Banana (sold out)", value: "banana", disabled: true },
       { label: "Cherry", value: "cherry" },
     ],
+  },
+};
+
+export const Clearable: Story = {
+  args: {
+    label: "Fruit",
+    placeholder: "Select a fruit",
+    clearable: true,
+  },
+  render: (args) => {
+    const [value, setValue] = useState("banana");
+    return <Select {...args} value={value} onChange={setValue} />;
   },
 };
 

--- a/src/components/atoms/Select/Select.test.tsx
+++ b/src/components/atoms/Select/Select.test.tsx
@@ -68,6 +68,26 @@ describe("Select", () => {
     expect(placeholderOption).toBeDisabled();
   });
 
+  it("clearable=true のとき placeholder の option が選択可能になる", () => {
+    render(
+      <Select
+        options={defaultOptions}
+        placeholder="Select a fruit"
+        value=""
+        clearable
+      />,
+    );
+    const placeholderOption = screen.getByRole("option", {
+      name: "Select a fruit",
+    });
+    expect(placeholderOption).not.toBeDisabled();
+  });
+
+  it("placeholder 指定時の未選択状態が安定し、初期値は空文字になる", () => {
+    render(<Select options={defaultOptions} placeholder="Select a fruit" />);
+    expect(screen.getByRole("combobox")).toHaveValue("");
+  });
+
   it("選択変更で onChange が呼ばれる", async () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();
@@ -149,6 +169,72 @@ describe("Select", () => {
   it("name 属性がセットされる", () => {
     render(<Select options={defaultOptions} name="fruit" />);
     expect(screen.getByRole("combobox")).toHaveAttribute("name", "fruit");
+  });
+
+  it('clearable=true のとき選択解除で onChange("") が呼ばれる', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <Select
+        options={defaultOptions}
+        value="banana"
+        placeholder="Select a fruit"
+        clearable
+        onChange={handleChange}
+      />,
+    );
+
+    await user.selectOptions(screen.getByRole("combobox"), "");
+    expect(handleChange).toHaveBeenCalledWith("");
+  });
+
+  it("id / aria-* が透過される", () => {
+    render(
+      <Select
+        options={defaultOptions}
+        id="fruit-select"
+        aria-label="Fruit"
+        aria-describedby="hint-id"
+      />,
+    );
+    const select = screen.getByRole("combobox");
+    expect(select).toHaveAttribute("id", "fruit-select");
+    expect(select).toHaveAttribute("aria-label", "Fruit");
+    expect(select).toHaveAttribute("aria-describedby", "hint-id");
+  });
+
+  it("error があるとき aria-describedby に既存値と error id の両方が入る", () => {
+    render(
+      <Select
+        options={defaultOptions}
+        error="Error"
+        aria-describedby="hint-id"
+      />,
+    );
+    const select = screen.getByRole("combobox");
+    const errorElement = screen.getByRole("alert");
+    expect(select).toHaveAttribute(
+      "aria-describedby",
+      `hint-id ${errorElement.id}`,
+    );
+  });
+
+  it("onFocus / onBlur が呼ばれる", async () => {
+    const user = userEvent.setup();
+    const handleFocus = vi.fn();
+    const handleBlur = vi.fn();
+    render(
+      <Select
+        options={defaultOptions}
+        onFocus={handleFocus}
+        onBlur={handleBlur}
+      />,
+    );
+    const select = screen.getByRole("combobox");
+    await user.click(select);
+    await user.tab();
+    expect(handleFocus).toHaveBeenCalled();
+    expect(handleBlur).toHaveBeenCalled();
   });
 
   it("className がルートラッパーに渡される", () => {


### PR DESCRIPTION
## Summary
- Selectにclearableオプションを追加し、placeholderを再選択して未選択へ戻せるようにしました
- SelectPropsをネイティブselect属性ベースに拡張し、name / id / onBlur / onFocus / aria-* などを透過可能にしました
- placeholder指定時はdefaultValue=""を使って未選択状態を安定化しました
- Storybookにclear操作を確認できるClearableストーリーを追加しました
- READMEにSelectの利用例と透過属性の説明を追記しました

## Test
- pnpm vitest run src/components/atoms/Select/Select.test.tsx
- pnpm typecheck

Closes #29