### PR TITLE
feat(button): add tone axis for icon-only semantic variants

### DIFF
--- a/src/components/atoms/Button/Button.stories.tsx
+++ b/src/components/atoms/Button/Button.stories.tsx
@@ -151,10 +151,20 @@ const IconPlus = (
 export const IconOnlySemanticTones: Story = {
   render: () => (
     <div className="flex items-center gap-3">
-      <Button iconOnly variant="success" tone="plain" aria-label="success plain">
+      <Button
+        iconOnly
+        variant="success"
+        tone="plain"
+        aria-label="success plain"
+      >
         {IconPlus}
       </Button>
-      <Button iconOnly variant="success" tone="subtle" aria-label="success subtle">
+      <Button
+        iconOnly
+        variant="success"
+        tone="subtle"
+        aria-label="success subtle"
+      >
         {IconPlus}
       </Button>
       <Button iconOnly variant="info" tone="plain" aria-label="info plain">
@@ -166,7 +176,12 @@ export const IconOnlySemanticTones: Story = {
       <Button iconOnly variant="danger" tone="plain" aria-label="danger plain">
         {IconPlus}
       </Button>
-      <Button iconOnly variant="danger" tone="subtle" aria-label="danger subtle">
+      <Button
+        iconOnly
+        variant="danger"
+        tone="subtle"
+        aria-label="danger subtle"
+      >
         {IconPlus}
       </Button>
     </div>

--- a/src/components/atoms/Button/Button.test.tsx
+++ b/src/components/atoms/Button/Button.test.tsx
@@ -128,6 +128,9 @@ describe("Button", () => {
       </Button>,
     );
 
-    expect(screen.getByRole("button")).toHaveClass("bg-primary-main", "text-white");
+    expect(screen.getByRole("button")).toHaveClass(
+      "bg-primary-main",
+      "text-white",
+    );
   });
 });

--- a/src/components/atoms/Button/Button.tsx
+++ b/src/components/atoms/Button/Button.tsx
@@ -40,8 +40,7 @@ const variantStyles: Record<ButtonVariant, string> = {
     "bg-primary-main hover:bg-primary-light text-white dark:bg-blue-700 dark:hover:bg-blue-800",
   secondary:
     "bg-secondary-light hover:bg-gray-200 text-primary-main dark:bg-gray-700 dark:hover:bg-gray-600 dark:text-gray-200",
-  success:
-    "bg-[var(--kui-color-success)] hover:opacity-90 text-white",
+  success: "bg-[var(--kui-color-success)] hover:opacity-90 text-white",
   info: "bg-[var(--kui-color-info)] hover:opacity-90 text-white",
   outline:
     "bg-transparent border border-primary-main text-primary-main hover:bg-primary-main/5 dark:border-blue-500 dark:text-blue-400 dark:hover:bg-blue-900/20",
@@ -90,7 +89,9 @@ const semanticToneStyles: Record<
   },
 };
 
-const isSemanticVariant = (variant: ButtonVariant): variant is SemanticVariant => {
+const isSemanticVariant = (
+  variant: ButtonVariant,
+): variant is SemanticVariant => {
   return variant === "success" || variant === "info" || variant === "danger";
 };
 


### PR DESCRIPTION
## 概要
- Button に variant とは独立した tone プロップ（solid / plain / subtle）を追加
- info variant を追加し、success / danger / info の配色をデザイントークンベースに変更
- iconOnly 向けの semantic tone パターンを Storybook に追加
- semantic tone の適用と non-semantic variant のフォールバック挙動をテスト追加

## 動作確認
- pnpm vitest run src/components/atoms/Button/Button.test.tsx
- pnpm typecheck

Closes #30