### PR TITLE
feat: EmptyStateにsize/align/action配置バリエーションを追加

### DIFF
--- a/src/components/templates/EmptyState/EmptyState.stories.tsx
+++ b/src/components/templates/EmptyState/EmptyState.stories.tsx
@@ -26,6 +26,20 @@ const meta = {
   parameters: {
     layout: "centered",
   },
+  argTypes: {
+    size: {
+      control: "select",
+      options: ["sm", "md", "lg"],
+    },
+    align: {
+      control: "select",
+      options: ["left", "center"],
+    },
+    actionPlacement: {
+      control: "select",
+      options: ["below", "inline"],
+    },
+  },
 } satisfies Meta<typeof EmptyState>;
 
 export default meta;
@@ -35,6 +49,9 @@ export const Default: Story = {
   args: {
     title: "No data available",
     description: "Add your first item to get started.",
+    size: "md",
+    align: "center",
+    actionPlacement: "below",
   },
 };
 
@@ -44,11 +61,42 @@ export const WithIconAndAction: Story = {
     title: "No trips found",
     description: "Create a trip and manage your travel schedule.",
     action: <Button variant="primary">Create trip</Button>,
+    size: "md",
+    align: "center",
+    actionPlacement: "below",
   },
 };
 
 export const TitleOnly: Story = {
   args: {
     title: "No messages",
+    size: "md",
+    align: "center",
+  },
+};
+
+export const ListEmptyState: Story = {
+  args: {
+    icon: <CalendarIcon />,
+    title: "表示できる案件がありません",
+    description: "条件に一致するデータがまだ登録されていません。",
+    action: <Button variant="secondary">新規作成</Button>,
+    size: "lg",
+    align: "left",
+    actionPlacement: "below",
+  },
+  parameters: {
+    layout: "padded",
+  },
+};
+
+export const NoSearchResults: Story = {
+  args: {
+    title: "検索結果が見つかりません",
+    description: "キーワードやフィルターを変更して再検索してください。",
+    action: <Button variant="ghost">条件をリセット</Button>,
+    size: "sm",
+    align: "center",
+    actionPlacement: "inline",
   },
 };

--- a/src/components/templates/EmptyState/EmptyState.test.tsx
+++ b/src/components/templates/EmptyState/EmptyState.test.tsx
@@ -55,4 +55,35 @@ describe("EmptyState", () => {
     const emptyState = screen.getByTestId("empty-state");
     expect(emptyState).toHaveAttribute("id", "empty");
   });
+
+  it("size ごとのクラスが適用される", () => {
+    render(<EmptyState title="No data" size="lg" data-testid="empty-state" />);
+    const emptyState = screen.getByTestId("empty-state");
+    expect(emptyState).toHaveClass("px-8");
+    expect(emptyState).toHaveClass("py-14");
+  });
+
+  it("align=left で左寄せクラスが適用される", () => {
+    render(
+      <EmptyState title="No data" align="left" data-testid="empty-state" />,
+    );
+    const emptyState = screen.getByTestId("empty-state");
+    expect(emptyState).toHaveClass("items-start");
+    expect(emptyState).toHaveClass("text-left");
+  });
+
+  it("actionPlacement=inline で action が末尾に表示される", () => {
+    render(
+      <EmptyState
+        title="No data"
+        description="desc"
+        action={<button type="button">Reset</button>}
+        actionPlacement="inline"
+      />,
+    );
+
+    const actionButton = screen.getByRole("button", { name: "Reset" });
+    const description = screen.getByText("desc");
+    expect(description.nextElementSibling).toContainElement(actionButton);
+  });
 });

--- a/src/components/templates/EmptyState/EmptyState.tsx
+++ b/src/components/templates/EmptyState/EmptyState.tsx
@@ -4,6 +4,10 @@ import type React from "react";
 import { cn } from "../../../utils/cn";
 import { Heading, Typography } from "../../atoms";
 
+export type EmptyStateSize = "sm" | "md" | "lg";
+export type EmptyStateAlign = "left" | "center";
+export type EmptyStateActionPlacement = "below" | "inline";
+
 export interface EmptyStateProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * 空状態を表すアイコン
@@ -21,7 +25,59 @@ export interface EmptyStateProps extends React.HTMLAttributes<HTMLDivElement> {
    * アクション要素（ボタン等）
    */
   action?: React.ReactNode;
+  /**
+   * コンポーネント全体のサイズ
+   */
+  size?: EmptyStateSize;
+  /**
+   * コンテンツの水平方向の配置
+   */
+  align?: EmptyStateAlign;
+  /**
+   * action の配置
+   */
+  actionPlacement?: EmptyStateActionPlacement;
 }
+
+const containerSizeClassMap: Record<EmptyStateSize, string> = {
+  sm: "gap-2 rounded-lg px-4 py-6",
+  md: "gap-3 rounded-xl px-6 py-10",
+  lg: "gap-4 rounded-2xl px-8 py-14",
+};
+
+const headingSizeMap: Record<EmptyStateSize, "sm" | "md" | "lg"> = {
+  sm: "sm",
+  md: "md",
+  lg: "lg",
+};
+
+const descriptionVariantMap: Record<EmptyStateSize, "body-sm" | "body-md"> = {
+  sm: "body-sm",
+  md: "body-sm",
+  lg: "body-md",
+};
+
+const descriptionWidthClassMap: Record<EmptyStateSize, string> = {
+  sm: "max-w-sm",
+  md: "max-w-md",
+  lg: "max-w-lg",
+};
+
+const iconSizeClassMap: Record<EmptyStateSize, string> = {
+  sm: "h-10 w-10",
+  md: "h-12 w-12",
+  lg: "h-14 w-14",
+};
+
+const contentAlignClassMap: Record<EmptyStateAlign, string> = {
+  left: "items-start text-left",
+  center: "items-center text-center",
+};
+
+const actionWrapAlignClassMap: Record<EmptyStateAlign, string> = {
+  left: "justify-start",
+  center: "justify-center",
+};
 
 /**
  * EmptyState コンポーネント
@@ -36,34 +92,51 @@ export const EmptyState: React.FC<EmptyStateProps> = ({
   title,
   description,
   action,
+  size = "md",
+  align = "center",
+  actionPlacement = "below",
   className,
   ...props
 }) => {
   return (
     <div
       className={cn(
-        "flex w-full flex-col items-center justify-center gap-3 rounded-xl border border-[--kui-color-border] bg-[--kui-color-surface] px-6 py-10 text-center",
+        "flex w-full flex-col justify-center border border-[--kui-color-border] bg-[--kui-color-surface]",
+        containerSizeClassMap[size],
+        contentAlignClassMap[align],
         className,
       )}
       {...props}
     >
       {icon ? (
         <div
-          className="flex h-12 w-12 items-center justify-center text-[--kui-color-text-muted]"
+          className={cn(
+            "flex items-center justify-center text-[--kui-color-text-muted]",
+            iconSizeClassMap[size],
+          )}
           aria-hidden="true"
         >
           {icon}
         </div>
       ) : null}
-      <Heading as="h2" size="md">
+      <Heading as="h2" size={headingSizeMap[size]}>
         {title}
       </Heading>
       {description ? (
-        <Typography className="max-w-md" variant="body-sm" tone="muted">
+        <Typography
+          className={descriptionWidthClassMap[size]}
+          variant={descriptionVariantMap[size]}
+          tone="muted"
+        >
           {description}
         </Typography>
       ) : null}
-      {action ? <div className="pt-1">{action}</div> : null}
+      {action && actionPlacement === "inline" ? <div>{action}</div> : null}
+      {action && actionPlacement === "below" ? (
+        <div className={cn("flex w-full pt-1", actionWrapAlignClassMap[align])}>
+          {action}
+        </div>
+      ) : null}
     </div>
   );
 };


### PR DESCRIPTION
## 概要
- EmptyStateにsize（sm/md/lg）を追加
- EmptyStateにalign（left/center）を追加
- EmptyStateにactionPlacement（below/inline）を追加
- Storybookに用途別サンプル（一覧空状態・検索結果なし）を追加
- EmptyStateのテストを拡張

## 変更内容
- EmptyState.tsx
  - サイズ別の余白・アイコンサイズ・見出しサイズ・説明文サイズを切り替え
  - 配置別にテキスト寄せとactionの配置を切り替え
- EmptyState.stories.tsx
  - size / align / actionPlacement のコントロールを追加
  - ListEmptyState と NoSearchResults ストーリーを追加
- EmptyState.test.tsx
  - size/align/actionPlacementの挙動テストを追加

## 動作確認
- pnpm vitest run src/components/templates/EmptyState/EmptyState.test.tsx
- pnpm biome check src/components/templates/EmptyState/EmptyState.tsx src/components/templates/EmptyState/EmptyState.stories.tsx src/components/templates/EmptyState/EmptyState.test.tsx

Closes #35
