### PR TITLE
feat: DataTableに仮想スクロール対応を追加 (#53)

### DIFF
--- a/src/components/molecules/DataTable/DataTable.stories.tsx
+++ b/src/components/molecules/DataTable/DataTable.stories.tsx
@@ -37,6 +37,13 @@ const taskRows: TaskRow[] = [
   { id: "task-3", title: "Update docs", owner: "Ken", status: "Open" },
 ];
 
+const largeTaskRows: TaskRow[] = Array.from({ length: 2000 }, (_, idx) => ({
+  id: `task-${idx + 1}`,
+  title: `Task ${idx + 1}`,
+  owner: idx % 2 === 0 ? "Ken" : "Nao",
+  status: idx % 3 === 0 ? "Done" : "Open",
+}));
+
 const taskActions: DataTableAction<TaskRow>[] = [
   {
     label: "Edit",
@@ -111,6 +118,20 @@ export const MobileCards: Story = {
       getRowId={(row) => row.id}
       actions={taskActions}
       mobileMode="cards"
+    />
+  ),
+};
+
+export const VirtualizedLargeDataset: Story = {
+  render: () => (
+    <DataTable<TaskRow>
+      columns={taskColumns}
+      rows={largeTaskRows}
+      getRowId={(row) => row.id}
+      virtualized
+      height={420}
+      rowHeight={52}
+      overscan={6}
     />
   ),
 };

--- a/src/components/molecules/DataTable/DataTable.stories.tsx
+++ b/src/components/molecules/DataTable/DataTable.stories.tsx
@@ -128,10 +128,12 @@ export const VirtualizedLargeDataset: Story = {
       columns={taskColumns}
       rows={largeTaskRows}
       getRowId={(row) => row.id}
-      virtualized
-      height={420}
-      rowHeight={52}
-      overscan={6}
+      virtualization={{
+        enabled: true,
+        height: 420,
+        rowHeight: 52,
+        overscan: 6,
+      }}
     />
   ),
 };

--- a/src/components/molecules/DataTable/DataTable.test.tsx
+++ b/src/components/molecules/DataTable/DataTable.test.tsx
@@ -125,10 +125,12 @@ describe("DataTable", () => {
         columns={columns}
         rows={manyRows}
         getRowId={(row) => row.id}
-        virtualized
-        height={120}
-        rowHeight={40}
-        overscan={0}
+        virtualization={{
+          enabled: true,
+          height: 120,
+          rowHeight: 40,
+          overscan: 0,
+        }}
       />,
     );
 
@@ -148,10 +150,12 @@ describe("DataTable", () => {
         columns={columns}
         rows={manyRows}
         getRowId={(row) => row.id}
-        virtualized
-        height={120}
-        rowHeight={40}
-        overscan={0}
+        virtualization={{
+          enabled: true,
+          height: 120,
+          rowHeight: 40,
+          overscan: 0,
+        }}
       />,
     );
 

--- a/src/components/molecules/DataTable/DataTable.test.tsx
+++ b/src/components/molecules/DataTable/DataTable.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
@@ -111,5 +111,56 @@ describe("DataTable", () => {
 
     expect(screen.getAllByText("Name").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Nao").length).toBeGreaterThan(0);
+  });
+
+  it("virtualized=true で表示領域分のみ描画する", () => {
+    const manyRows: UserRow[] = Array.from({ length: 200 }, (_, idx) => ({
+      id: String(idx + 1),
+      name: `User ${idx + 1}`,
+      role: "Member",
+    }));
+
+    render(
+      <DataTable<UserRow>
+        columns={columns}
+        rows={manyRows}
+        getRowId={(row) => row.id}
+        virtualized
+        height={120}
+        rowHeight={40}
+        overscan={0}
+      />,
+    );
+
+    expect(screen.getByText("User 1")).toBeInTheDocument();
+    expect(screen.queryByText("User 120")).not.toBeInTheDocument();
+  });
+
+  it("virtualized=true でスクロール位置に応じた行を描画する", () => {
+    const manyRows: UserRow[] = Array.from({ length: 200 }, (_, idx) => ({
+      id: String(idx + 1),
+      name: `User ${idx + 1}`,
+      role: "Member",
+    }));
+
+    const { container } = render(
+      <DataTable<UserRow>
+        columns={columns}
+        rows={manyRows}
+        getRowId={(row) => row.id}
+        virtualized
+        height={120}
+        rowHeight={40}
+        overscan={0}
+      />,
+    );
+
+    const wrapper = container.querySelector("div[style*='overflow-y: auto']");
+    expect(wrapper).not.toBeNull();
+
+    fireEvent.scroll(wrapper as Element, { target: { scrollTop: 400 } });
+
+    expect(screen.queryByText("User 1")).not.toBeInTheDocument();
+    expect(screen.getByText("User 11")).toBeInTheDocument();
   });
 });

--- a/src/components/molecules/DataTable/DataTable.tsx
+++ b/src/components/molecules/DataTable/DataTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { ReactNode } from "react";
+import { type CSSProperties, type ReactNode, useMemo, useState } from "react";
 import { cn } from "../../../utils/cn";
 import { Button, Spinner, Typography } from "../../atoms";
 
@@ -63,6 +63,14 @@ export interface DataTableProps<T> {
   emptyMessage?: string;
   /** モバイル表示モード */
   mobileMode?: DataTableMobileMode;
+  /** 仮想スクロールを有効化（mobileMode=scroll のみ対応） */
+  virtualized?: boolean;
+  /** 仮想スクロール時の表示高さ */
+  height?: number | string;
+  /** 仮想スクロール時の1行高さ(px) */
+  rowHeight?: number;
+  /** 仮想スクロール時の前後描画行数 */
+  overscan?: number;
   /** 追加クラス */
   className?: string;
 }
@@ -125,10 +133,65 @@ export const DataTable = <T,>({
   loadingLabel = "Loading...",
   emptyMessage = "No data available.",
   mobileMode = "scroll",
+  virtualized = false,
+  height = 400,
+  rowHeight = 52,
+  overscan = 4,
   className,
 }: DataTableProps<T>) => {
   const hasActionColumn = Boolean(actions);
   const tableColumnCount = columns.length + (hasActionColumn ? 1 : 0);
+  const [scrollTop, setScrollTop] = useState(0);
+  const viewportHeight =
+    typeof height === "number"
+      ? height
+      : Number.parseInt(String(height).replace("px", ""), 10) || 400;
+  const shouldVirtualize = virtualized && mobileMode === "scroll";
+
+  const virtualizedWindow = useMemo(() => {
+    if (!shouldVirtualize || rows.length === 0) {
+      return {
+        startIndex: 0,
+        endIndex: rows.length,
+        topSpacerHeight: 0,
+        bottomSpacerHeight: 0,
+      };
+    }
+
+    const safeRowHeight = rowHeight > 0 ? rowHeight : 52;
+    const safeOverscan = overscan >= 0 ? overscan : 0;
+    const visibleCount = Math.ceil(viewportHeight / safeRowHeight);
+    const startIndex = Math.max(
+      0,
+      Math.floor(scrollTop / safeRowHeight) - safeOverscan,
+    );
+    const endIndex = Math.min(
+      rows.length,
+      startIndex + visibleCount + safeOverscan * 2,
+    );
+
+    return {
+      startIndex,
+      endIndex,
+      topSpacerHeight: startIndex * safeRowHeight,
+      bottomSpacerHeight: Math.max(0, (rows.length - endIndex) * safeRowHeight),
+    };
+  }, [
+    shouldVirtualize,
+    rows.length,
+    rowHeight,
+    overscan,
+    viewportHeight,
+    scrollTop,
+  ]);
+
+  const visibleRows = shouldVirtualize
+    ? rows.slice(virtualizedWindow.startIndex, virtualizedWindow.endIndex)
+    : rows;
+
+  const tableWrapperStyle: CSSProperties | undefined = shouldVirtualize
+    ? { height, overflowY: "auto" }
+    : undefined;
 
   if (isLoading) {
     return (
@@ -251,6 +314,12 @@ export const DataTable = <T,>({
         "w-full overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700",
         className,
       )}
+      style={tableWrapperStyle}
+      onScroll={
+        shouldVirtualize
+          ? (event) => setScrollTop(event.currentTarget.scrollTop)
+          : undefined
+      }
     >
       <table className="min-w-full border-collapse">
         <thead className="bg-gray-50 dark:bg-gray-800/60">
@@ -286,29 +355,59 @@ export const DataTable = <T,>({
               </td>
             </tr>
           ) : (
-            rows.map((row, index) => (
-              <tr
-                key={getRowId(row, index)}
-                className="bg-white dark:bg-gray-900"
-              >
-                {columns.map((column) => (
+            <>
+              {shouldVirtualize && virtualizedWindow.topSpacerHeight > 0 && (
+                <tr>
                   <td
-                    key={column.key}
-                    className={cn(
-                      "px-4 py-3 text-sm text-gray-700 dark:text-gray-200",
-                      column.cellClassName,
-                    )}
+                    colSpan={tableColumnCount}
+                    style={{
+                      height: `${virtualizedWindow.topSpacerHeight}px`,
+                      padding: 0,
+                    }}
+                  />
+                </tr>
+              )}
+              {visibleRows.map((row, index) => {
+                const rowIndex = shouldVirtualize
+                  ? virtualizedWindow.startIndex + index
+                  : index;
+
+                return (
+                  <tr
+                    key={getRowId(row, rowIndex)}
+                    className="bg-white dark:bg-gray-900"
                   >
-                    {column.render(row)}
-                  </td>
-                ))}
-                {hasActionColumn && (
-                  <td className="px-4 py-3 text-right">
-                    {renderActions(row, actions)}
-                  </td>
-                )}
-              </tr>
-            ))
+                    {columns.map((column) => (
+                      <td
+                        key={column.key}
+                        className={cn(
+                          "px-4 py-3 text-sm text-gray-700 dark:text-gray-200",
+                          column.cellClassName,
+                        )}
+                      >
+                        {column.render(row)}
+                      </td>
+                    ))}
+                    {hasActionColumn && (
+                      <td className="px-4 py-3 text-right">
+                        {renderActions(row, actions)}
+                      </td>
+                    )}
+                  </tr>
+                );
+              })}
+              {shouldVirtualize && virtualizedWindow.bottomSpacerHeight > 0 && (
+                <tr>
+                  <td
+                    colSpan={tableColumnCount}
+                    style={{
+                      height: `${virtualizedWindow.bottomSpacerHeight}px`,
+                      padding: 0,
+                    }}
+                  />
+                </tr>
+              )}
+            </>
           )}
         </tbody>
       </table>


### PR DESCRIPTION
## Summary
- DataTableにvirtualized/height/rowHeight/overscanを追加
- 表示領域+overscan分のみ描画する仮想スクロールを実装
- 大規模データのStorybookを追加
- 単体テストを追加

## Test
- pnpm exec biome check src/components/molecules/DataTable/DataTable.tsx src/components/molecules/DataTable/DataTable.test.tsx src/components/molecules/DataTable/DataTable.stories.tsx
- pnpm exec vitest run src/components/molecules/DataTable/DataTable.test.tsx
- pnpm typecheck